### PR TITLE
Fix : 로그인 페이지 리팩토링 작업

### DIFF
--- a/components/auth/Login.tsx
+++ b/components/auth/Login.tsx
@@ -4,7 +4,7 @@ import { signInWithEmailAndPassword } from "firebase/auth";
 import { emailRegex, pwRegex } from "@/util";
 import { useRouter } from "next/router";
 
-const Login = () => {
+const Login = ({ setStatus, status }: { setStatus: any; status: string }) => {
   const emailRef = useRef<HTMLInputElement>(null);
   const pwRef = useRef<HTMLInputElement>(null);
   const [email, setEmail] = useState("");
@@ -101,6 +101,29 @@ const Login = () => {
       >
         로그인하기
       </button>
+      <br />
+      {status === "login" ? (
+        <div>
+          <button
+            type="button"
+            onClick={() => {
+              setStatus("signUp");
+            }}
+          >
+            회원가입하기
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setStatus("searchPW");
+            }}
+          >
+            비밀번호 찾기
+          </button>
+        </div>
+      ) : (
+        ""
+      )}
     </div>
   );
 };

--- a/components/auth/Register.tsx
+++ b/components/auth/Register.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { authService } from "@/config/firebase";
 import {
   createUserWithEmailAndPassword,
@@ -18,6 +18,21 @@ const RegisterPage = () => {
   const [pw, setPw] = useState("");
   const [pwConfirm, setPwConfirm] = useState("");
   const [nickname, setNickname] = useState("");
+
+  // 브라우저 뒤로가기 버튼시 confirm창과 함께 "확인"클릭시 로그인 페이지로 이동하는 함수입니다.
+  useEffect(() => {
+    window.history.pushState(null, "null", document.URL);
+    console.log("document.URL:", document.URL);
+    window.addEventListener("popstate", function (event) {
+      const result = window.confirm("정말 나가시겠습니까?");
+      if (result) {
+        window.location.replace(`/loginPage`);
+      }
+      if (!result) {
+        return false;
+      }
+    });
+  }, []);
 
   // 유효성검사
   const validInputs = () => {

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -37,7 +37,7 @@ const Header = () => {
             로그아웃
           </button>
         ) : (
-          <Link href="/loginPage">로그인</Link>
+          <a href="/loginPage">로그인</a>
         )}
 
         <Link href="/myPage">마이페이지</Link>

--- a/pages/loginPage/index.tsx
+++ b/pages/loginPage/index.tsx
@@ -1,35 +1,18 @@
 import Login from "@/components/auth/Login";
 import Register from "@/components/auth/Register";
 import Header from "@/components/layout/Header";
-import Link from "next/link";
 import React, { useState } from "react";
 
 const LoginPage = () => {
-    const [status, setStatus] = useState("login");
-    return (
-        <div>
-            Login Page입니다.
-            {status === "login" && <Login />}
-            {status === "signUp" && <Register />}
-            {status === "searchPW" && <Header />}
-            <button
-                type="button"
-                onClick={() => {
-                    setStatus("signUp");
-                }}
-            >
-                회원가입하기
-            </button>
-            <button
-                type="button"
-                onClick={() => {
-                    setStatus("searchPW");
-                }}
-            >
-                비밀번호 찾기
-            </button>
-        </div>
-    );
+  const [status, setStatus] = useState("login");
+  return (
+    <div>
+      Login Page입니다.
+      {status === "login" && <Login setStatus={setStatus} status={status} />}
+      {status === "signUp" && <Register />}
+      {status === "searchPW" && <Header />}
+    </div>
+  );
 };
 
 export default LoginPage;


### PR DESCRIPTION

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
refactor/login-page -> dev

### 변경 사항

- 기존 로그인 페이지의 index 페이지의 "회원가입하기","비밀번호 찾기" 버튼을 Login 컴포넌트로 이동시켰습니다.
- index 페이지의 Login 컴포넌트에 status 스테이트와 set함수를 내려주어, Login 컴포넌트 내에서 보이도록 리팩토링하였습니다.
- Register 컴포넌트 내에 브라우저 뒤로가기 버튼 클릭시, confirm 창이 뜨고 "확인" 클릭시 Login 페이지로 다시 랜더링이 되도록 로직 추가하였습니다.
- Header의 기존 "로그인" 태그를 a 태그로 변경하였습니다 ( 이유 : 로그인 페이지 내에서 헤더의 "로그인" 버튼을 누르면, 로그인 페이지로 이동하지 않는 이슈가 있었습니다 )

** 추가사항 : Register 컴포넌트에 "뒤로가기" 버튼 추가가 필요합니다. / Login 컴포넌트 내에 "비밀번호 찾기" 버튼 클릭시 해당 컴포넌트가 나올 수 있도록 로직 수정 필요합니다.

